### PR TITLE
Implement persistent vault storage

### DIFF
--- a/backend/core/geoid.py
+++ b/backend/core/geoid.py
@@ -19,10 +19,15 @@ class GeoidState:
                 self.semantic_state = {k: v/total for k, v in self.semantic_state.items()}
 
     def calculate_entropy(self) -> float:
+        """Calculate Shannon entropy of the semantic state."""
         if not self.semantic_state:
             return 0.0
-        probs = list(self.semantic_state.values())
-        return float(-sum(p * np.log2(p) for p in probs if p > 0))
+
+        probabilities = np.array(list(self.semantic_state.values()))
+        probabilities = probabilities[probabilities > 0]
+        if probabilities.size == 0:
+            return 0.0
+        return float(-np.sum(probabilities * np.log2(probabilities)))
 
     def update_semantic_state(self, new_features: Dict[str, float]):
         self.semantic_state.update(new_features)

--- a/backend/vault/database.py
+++ b/backend/vault/database.py
@@ -1,0 +1,30 @@
+from sqlalchemy import create_engine, Column, String, Float, Integer, JSON, DateTime
+from sqlalchemy.orm import sessionmaker, declarative_base
+from datetime import datetime
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./kimera_swm.db")
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+class ScarDB(Base):
+    __tablename__ = "scars"
+
+    scar_id = Column(String, primary_key=True, index=True)
+    geoids = Column(JSON)
+    reason = Column(String)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    resolved_by = Column(String)
+    pre_entropy = Column(Float)
+    post_entropy = Column(Float)
+    delta_entropy = Column(Float)
+    cls_angle = Column(Float)
+    semantic_polarity = Column(Float)
+    mutation_frequency = Column(Float)
+    vault_id = Column(String, index=True)
+
+# Create tables if they don't exist
+Base.metadata.create_all(bind=engine)

--- a/backend/vault/vault_manager.py
+++ b/backend/vault/vault_manager.py
@@ -1,13 +1,53 @@
 from __future__ import annotations
-from typing import Dict
+from typing import List
+from datetime import datetime
 
 from ..core.scar import ScarRecord
+from .database import SessionLocal, ScarDB
+
 
 class VaultManager:
-    def __init__(self):
-        self.vault_a: Dict[str, ScarRecord] = {}
-        self.vault_b: Dict[str, ScarRecord] = {}
+    """Manage persistence of Scar records across multiple vaults."""
 
-    def insert_scar(self, scar: ScarRecord) -> None:
-        target = self.vault_a if len(self.vault_a) <= len(self.vault_b) else self.vault_b
-        target[scar.scar_id] = scar
+    def __init__(self):
+        self.db = SessionLocal()
+
+    def _select_vault(self) -> str:
+        """Choose a vault based on current counts."""
+        a_count = self.get_total_scar_count("vault_a")
+        b_count = self.get_total_scar_count("vault_b")
+        return "vault_a" if a_count <= b_count else "vault_b"
+
+    def insert_scar(self, scar: ScarRecord) -> ScarDB:
+        """Insert a ScarRecord into the persistent store."""
+        vault_id = self._select_vault()
+        scar_db = ScarDB(
+            scar_id=scar.scar_id,
+            geoids=scar.geoids,
+            reason=scar.reason,
+            timestamp=datetime.fromisoformat(scar.timestamp),
+            resolved_by=scar.resolved_by,
+            pre_entropy=scar.pre_entropy,
+            post_entropy=scar.post_entropy,
+            delta_entropy=scar.delta_entropy,
+            cls_angle=scar.cls_angle,
+            semantic_polarity=scar.semantic_polarity,
+            mutation_frequency=scar.mutation_frequency,
+            vault_id=vault_id,
+        )
+        self.db.add(scar_db)
+        self.db.commit()
+        self.db.refresh(scar_db)
+        return scar_db
+
+    def get_scars_from_vault(self, vault_id: str, limit: int = 100) -> List[ScarDB]:
+        return (
+            self.db.query(ScarDB)
+            .filter(ScarDB.vault_id == vault_id)
+            .order_by(ScarDB.timestamp.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def get_total_scar_count(self, vault_id: str) -> int:
+        return self.db.query(ScarDB).filter(ScarDB.vault_id == vault_id).count()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pydantic
 numpy
 scipy
 httpx
+SQLAlchemy
+psycopg2-binary


### PR DESCRIPTION
## Summary
- add SQLAlchemy database for storing Scar records
- refactor `VaultManager` to write and query persistent scars
- improve entropy calculation logic
- compute real metrics when generating scars
- add vault query endpoint and update status counts
- include new requirements for SQLAlchemy and psycopg2-binary

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451450cc508327b376f12199c3817d