### PR TITLE
Add persistent vector search for geoids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+*.db

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ scipy
 httpx
 SQLAlchemy
 psycopg2-binary
+
+pgvector
+sentence-transformers

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,3 +26,14 @@ def test_create_geoid_and_status():
     results = contr.json()
     assert 'analysis_results' in results
     assert 'scars_created' in results
+
+def test_geoid_search():
+    # create geoid to search for
+    create = client.post('/geoids', json={'semantic_features': {'alpha': 1.0}})
+    assert create.status_code == 200
+    gid = create.json()['geoid_id']
+
+    res = client.get('/geoids/search', params={'query': 'alpha'})
+    assert res.status_code == 200
+    data = res.json()
+    assert any(g['geoid_id'] == gid for g in data['similar_geoids'])


### PR DESCRIPTION
### **User description**
## Summary
- persist geoid embeddings using pgvector
- load sentence-transformers model in API
- store new geoids with vector embeddings
- add `/geoids/search` endpoint
- test semantic search

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451834ab248327a1707c530e81165c


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add persistent semantic vector storage for geoids using pgvector.
  - Store geoid embeddings in the database on creation.
  - Use SentenceTransformer to generate semantic vectors.

- Implement semantic search endpoint for geoids.
  - Add `/geoids/search` API to find similar geoids by query.

- Add tests for geoid semantic search functionality.

- Update dependencies for vector search and embeddings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add semantic vector storage and search API for geoids</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/api/main.py

<li>Load SentenceTransformer model at startup for embeddings.<br> <li> Store semantic vectors in the database when creating geoids.<br> <li> Add <code>/geoids/search</code> endpoint for semantic similarity search.<br> <li> Query database for similar geoids using vector distance.


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/7/files#diff-7edeb9df8aa8ec3c8e87e46c4f9bb574f848c16cb5a061fcc640ce4cadfefca3">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>database.py</strong><dd><code>Add persistent geoid vector storage with pgvector support</code></dd></summary>
<hr>

backend/vault/database.py

<li>Add <code>GeoidDB</code> model with persistent semantic vector field.<br> <li> Use pgvector for Postgres or JSON fallback for SQLite.<br> <li> Ensure vector extension is enabled for Postgres.<br> <li> Create new <code>geoids</code> table for semantic storage.


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/7/files#diff-974b7fe03942e7f3895440efcb971bf81fe91df7b9f8e45caf99f7f556467a82">+24/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Add tests for geoid semantic search endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_api.py

<li>Add test for geoid semantic search endpoint.<br> <li> Validate that created geoids are found via semantic search.


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/7/files#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Add dependencies for vector search and embeddings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements.txt

- Add `pgvector` and `sentence-transformers` dependencies.


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/7/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>