### PR TITLE
Add simple React dashboard and stability endpoint

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -356,6 +356,16 @@ async def get_system_status():
         'cycle_count': kimera_system['system_state']['cycle_count']
     }
 
+
+@app.get("/system/stability")
+async def get_system_stability():
+    """Return global stability metrics from the Axis Stability Monitor."""
+    db = SessionLocal()
+    asm = AxisStabilityMonitor(db)
+    metrics = asm.get_stability_metrics()
+    db.close()
+    return metrics
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,12 @@
+# KIMERA SWM Dashboard
+
+This folder contains a minimal React dashboard for interacting with the MVP API.
+
+Open `index.html` in a web browser while the FastAPI server is running
+(on `http://localhost:8000` by default). The dashboard provides three main views:
+
+- **System Health** – displays metrics from `/system/status` and `/system/stability`.
+- **Geoid Explorer** – search for geoids and trigger contradiction processing.
+- **Vault Inspector** – lists recent scars from `vault_a` and `vault_b`.
+
+No build step is required as React is loaded from a CDN.

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,0 +1,121 @@
+const { useState, useEffect } = React;
+
+const API_BASE = '';
+
+function SystemHealthDashboard() {
+  const [metrics, setMetrics] = useState(null);
+
+  const fetchData = async () => {
+    const status = await fetch(`${API_BASE}/system/status`).then(r => r.json());
+    let stability = {};
+    try {
+      stability = await fetch(`${API_BASE}/system/stability`).then(r => r.json());
+    } catch (e) {
+      console.error(e);
+    }
+    setMetrics({ ...status, ...stability });
+  };
+
+  useEffect(() => { fetchData(); }, []);
+
+  if (!metrics) return React.createElement('p', null, 'Loading...');
+
+  return (
+    <div className="section">
+      <h2>System Health</h2>
+      <ul>
+        <li>Active Geoids: {metrics.active_geoids}</li>
+        <li>Vault A Scars: {metrics.vault_a_scars}</li>
+        <li>Vault B Scars: {metrics.vault_b_scars}</li>
+        <li>Cycle Count: {metrics.cycle_count}</li>
+        <li>System Entropy: {metrics.system_entropy?.toFixed?.(3)}</li>
+        {metrics.vault_pressure !== undefined && (
+          <>
+            <li>Vault Pressure: {metrics.vault_pressure.toFixed(2)}</li>
+            <li>Semantic Cohesion: {metrics.semantic_cohesion.toFixed(2)}</li>
+            <li>Entropic Stability: {metrics.entropic_stability.toFixed(2)}</li>
+          </>
+        )}
+      </ul>
+    </div>
+  );
+}
+
+function GeoidExplorer() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+
+  const search = async () => {
+    const r = await fetch(`${API_BASE}/geoids/search?query=${encodeURIComponent(query)}`).then(r => r.json());
+    setResults(r.similar_geoids || []);
+  };
+
+  const trigger = async (gid) => {
+    await fetch(`${API_BASE}/process/contradictions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ trigger_geoid_id: gid, search_limit: 5 })
+    });
+    alert('Contradiction analysis complete');
+  };
+
+  return (
+    <div className="section">
+      <h2>Geoid Explorer</h2>
+      <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Search geoids" />
+      <button onClick={search}>Search</button>
+      <ul>
+        {results.map(g => (
+          <li key={g.geoid_id}>
+            {g.geoid_id}
+            <button onClick={() => trigger(g.geoid_id)}>Process</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function VaultInspector() {
+  const [vaultA, setA] = useState([]);
+  const [vaultB, setB] = useState([]);
+
+  const fetchVaults = async () => {
+    const a = await fetch(`${API_BASE}/vaults/vault_a`).then(r => r.json());
+    const b = await fetch(`${API_BASE}/vaults/vault_b`).then(r => r.json());
+    setA(a.scars || []);
+    setB(b.scars || []);
+  };
+
+  useEffect(() => { fetchVaults(); }, []);
+
+  return (
+    <div className="section">
+      <h2>Vault Inspector</h2>
+      <div style={{ display: 'flex', gap: '20px' }}>
+        <div>
+          <h3>Vault A</h3>
+          <ul>{vaultA.map(s => <li key={s.scar_id}>{s.scar_id}</li>)}</ul>
+        </div>
+        <div>
+          <h3>Vault B</h3>
+          <ul>{vaultB.map(s => <li key={s.scar_id}>{s.scar_id}</li>)}</ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <div>
+      <h1>KIMERA SWM Dashboard</h1>
+      <SystemHealthDashboard />
+      <GeoidExplorer />
+      <VaultInspector />
+    </div>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>KIMERA SWM Dashboard</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    h2 { margin-top: 1em; }
+    .section { border: 1px solid #ddd; padding: 10px; margin-bottom: 20px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -107,3 +107,12 @@ def test_autonomous_contradictions():
     assert search.status_code == 200
     sdata = search.json()
     assert 'similar_scars' in sdata
+
+
+def test_system_stability_endpoint():
+    res = client.get('/system/stability')
+    assert res.status_code == 200
+    data = res.json()
+    # Basic keys from AxisStabilityMonitor
+    assert 'vault_pressure' in data
+    assert 'semantic_cohesion' in data


### PR DESCRIPTION
## Summary
- add Axis Stability Monitor metrics endpoint
- test new `/system/stability` route
- build minimal React dashboard using CDN React

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c427dc6c83279015a26023366516