### PR TITLE
Implement Scar memory decay and background jobs

### DIFF
--- a/backend/engines/background_jobs.py
+++ b/backend/engines/background_jobs.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from datetime import datetime, timedelta
+from collections import defaultdict
+from typing import Callable, Optional
+
+from sqlalchemy.orm import Session
+
+from ..vault.database import SessionLocal, ScarDB, GeoidDB
+
+scheduler = BackgroundScheduler()
+_embedding_fn: Optional[Callable[[str], list[float]]] = None
+
+DECAY_RATE = 0.1
+CRYSTAL_WEIGHT_THRESHOLD = 20.0
+
+
+def decay_job() -> None:
+    db: Session = SessionLocal()
+    cutoff = datetime.utcnow() - timedelta(days=1)
+    scars = db.query(ScarDB).filter(ScarDB.last_accessed < cutoff).all()
+    for scar in scars:
+        scar.weight = max(scar.weight - DECAY_RATE, 0.0)
+    db.commit()
+    db.close()
+
+
+def fusion_job() -> None:
+    db: Session = SessionLocal()
+    groups: defaultdict[str, list[ScarDB]] = defaultdict(list)
+    for scar in db.query(ScarDB).all():
+        groups[scar.reason].append(scar)
+    for scars in groups.values():
+        if len(scars) > 2:
+            base = scars[0]
+            base.weight = sum(s.weight for s in scars)
+            for extra in scars[1:]:
+                db.delete(extra)
+    db.commit()
+    db.close()
+
+
+def crystallization_job() -> None:
+    if _embedding_fn is None:
+        return
+    db: Session = SessionLocal()
+    high_scars = db.query(ScarDB).filter(ScarDB.weight > CRYSTAL_WEIGHT_THRESHOLD).all()
+    for scar in high_scars:
+        geoid_id = f"CRYSTAL_{scar.scar_id}"
+        if db.query(GeoidDB).filter(GeoidDB.geoid_id == geoid_id).first():
+            continue
+        vector = _embedding_fn(scar.reason)
+        new_geoid = GeoidDB(
+            geoid_id=geoid_id,
+            symbolic_state={'principle': scar.reason},
+            metadata_json={},
+            semantic_state_json={},
+            semantic_vector=vector,
+        )
+        db.add(new_geoid)
+        scar.weight = 0.0
+    db.commit()
+    db.close()
+
+
+def start_background_jobs(embedding_fn: Callable[[str], list[float]]) -> None:
+    global _embedding_fn
+    _embedding_fn = embedding_fn
+    scheduler.add_job(decay_job, "interval", hours=1)
+    scheduler.add_job(fusion_job, "interval", hours=2)
+    scheduler.add_job(crystallization_job, "interval", hours=3)
+    scheduler.start()
+
+
+def stop_background_jobs() -> None:
+    if scheduler.running:
+        scheduler.shutdown(wait=False)

--- a/backend/vault/database.py
+++ b/backend/vault/database.py
@@ -34,6 +34,8 @@ class ScarDB(Base):
     cls_angle = Column(Float)
     semantic_polarity = Column(Float)
     mutation_frequency = Column(Float)
+    weight = Column(Float, default=1.0, nullable=False)
+    last_accessed = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     if DATABASE_URL.startswith("postgresql") and Vector is not None:
         scar_vector = Column(Vector(EMBEDDING_DIM))  # type: ignore
     else:

--- a/backend/vault/vault_manager.py
+++ b/backend/vault/vault_manager.py
@@ -33,6 +33,7 @@ class VaultManager:
             cls_angle=scar.cls_angle,
             semantic_polarity=scar.semantic_polarity,
             mutation_frequency=scar.mutation_frequency,
+            weight=scar.weight,
             scar_vector=vector,
             vault_id=vault_id,
         )
@@ -42,13 +43,18 @@ class VaultManager:
         return scar_db
 
     def get_scars_from_vault(self, vault_id: str, limit: int = 100) -> List[ScarDB]:
-        return (
+        scars = (
             self.db.query(ScarDB)
             .filter(ScarDB.vault_id == vault_id)
             .order_by(ScarDB.timestamp.desc())
             .limit(limit)
             .all()
         )
+        now = datetime.utcnow()
+        for s in scars:
+            s.last_accessed = now
+        self.db.commit()
+        return scars
 
     def get_total_scar_count(self, vault_id: str) -> int:
         return self.db.query(ScarDB).filter(ScarDB.vault_id == vault_id).count()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ psycopg2-binary
 
 pgvector
 sentence-transformers
+apscheduler

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.abspath("."))
 
 from fastapi.testclient import TestClient  # noqa: E402
 from backend.api.main import app, kimera_system  # noqa: E402
+from backend.vault.database import SessionLocal, ScarDB  # noqa: E402
 
 
 client = TestClient(app)
@@ -107,6 +108,13 @@ def test_autonomous_contradictions():
     assert search.status_code == 200
     sdata = search.json()
     assert 'similar_scars' in sdata
+
+    sid = sdata['similar_scars'][0]['scar_id']
+    db = SessionLocal()
+    scar = db.query(ScarDB).filter_by(scar_id=sid).first()
+    assert scar.weight >= 2.0
+    assert scar.last_accessed is not None
+    db.close()
 
 
 def test_system_stability_endpoint():


### PR DESCRIPTION
### **User description**
## Summary
- add weight and last_accessed columns to `ScarDB`
- implement APScheduler background jobs for decay, fusion and crystallization
- track scar usage and weight in the search API
- update vault manager to persist new fields
- run scheduler on startup and add apscheduler to requirements
- initialize scheduler through FastAPI startup/shutdown events
- verify scar weight updates in tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845cbaf1fc88327b5a6e7b40bf64663


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Add background jobs for scar memory decay, fusion, and crystallization
  - Implement periodic jobs using APScheduler
  - Integrate job lifecycle with FastAPI startup/shutdown events

- Track and update scar `weight` and `last_accessed` on access
  - Update search and vault retrieval APIs to persist usage metrics

- Extend `ScarDB` schema with `weight` and `last_accessed` fields

- Add and update tests to verify scar usage tracking and weight updates


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>background_jobs.py</strong><dd><code>Add background jobs for scar memory evolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/engines/background_jobs.py

<li>Introduced background job scheduler using APScheduler<br> <li> Added decay, fusion, and crystallization jobs for scars<br> <li> Enabled jobs to run at regular intervals and interact with DB<br> <li> Provided start/stop functions for integration with FastAPI lifecycle


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/22/files#diff-b5c188457334a1ba831af23879b48d2b1a0ea586d019e44c5eca42e4331ae1c6">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Integrate background jobs and update scar usage tracking</code>&nbsp; </dd></summary>
<hr>

backend/api/main.py

<li>Integrated background job start/stop with FastAPI events<br> <li> Updated scar search API to track and persist <code>weight</code> and <code>last_accessed</code><br> <li> Committed DB changes after updating scar usage metrics


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/22/files#diff-7edeb9df8aa8ec3c8e87e46c4f9bb574f848c16cb5a061fcc640ce4cadfefca3">+24/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>database.py</strong><dd><code>Extend ScarDB schema with usage tracking fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/vault/database.py

<li>Added <code>weight</code> and <code>last_accessed</code> columns to <code>ScarDB</code> model<br> <li> Set default values and update behavior for new fields


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/22/files#diff-974b7fe03942e7f3895440efcb971bf81fe91df7b9f8e45caf99f7f556467a82">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vault_manager.py</strong><dd><code>Track and persist scar usage in vault manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/vault/vault_manager.py

<li>Persisted <code>weight</code> when inserting new scars<br> <li> Updated <code>get_scars_from_vault</code> to refresh <code>last_accessed</code> and commit


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/22/files#diff-0259c558bd6720c2afe044266529ecce12315ec912a9a388faf0568729d66e4e">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Test scar usage tracking and weight updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_api.py

<li>Added assertions to verify scar <code>weight</code> and <code>last_accessed</code> updates<br> <li> Ensured scar usage metrics are tested after search


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/22/files#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Add APScheduler to requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements.txt

- Added `apscheduler` dependency for background job scheduling


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/22/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>