### PR TITLE
Handle different image extensions

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -179,7 +179,8 @@ async def create_geoid_from_image(file: UploadFile = File(...)):
     vector = clip_service.get_image_embedding(image)
 
     geoid_id = f"GEOID_IMG_{uuid.uuid4().hex[:8]}"
-    unique_filename = f"{uuid.uuid4().hex}.png"
+    ext = os.path.splitext(file.filename)[1] or ".bin"
+    unique_filename = f"{uuid.uuid4().hex}{ext}"
     geoid = GeoidState(
         geoid_id=geoid_id,
         symbolic_state={'type': 'image', 'filename': file.filename},


### PR DESCRIPTION
### **PR Type**
bug_fix, enhancement


___

### **Description**
- Preserve original image file extensions during upload.

- Improve file naming to handle various image formats.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Preserve and handle original image file extensions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/api/main.py

<li>Extracts and preserves the original file extension from uploaded <br>images.<br> <li> Updates unique filename generation to use the correct extension.<br> <li> Defaults to <code>.bin</code> if no extension is present.


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/28/files#diff-7edeb9df8aa8ec3c8e87e46c4f9bb574f848c16cb5a061fcc640ce4cadfefca3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>