### PR TITLE
Pin httpx version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains a minimal implementation of the KIMERA Semantic Working
 
 - Python 3.12+
 - See `requirements.txt` for Python package dependencies.
+- The `httpx` dependency is pinned to `<0.27` due to compatibility with
+  FastAPI's test client.
 
 Install dependencies with:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ uvicorn
 pydantic
 numpy
 scipy
-httpx
+httpx==0.24.*
 SQLAlchemy
 psycopg2-binary
 


### PR DESCRIPTION
## Summary
- pin `httpx` to `0.24.*`
- document FastAPI compatibility note in the README

## Testing
- `pytest tests/test_api.py::test_create_geoid_and_status -q`

------
https://chatgpt.com/codex/tasks/task_e_68460090962c83279618fc3f3198ce20