### PR TITLE
Update testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ The API exposes endpoints for managing geoids and scars. Static images are serve
 
 ## Testing
 
-Unit tests are located in the `tests` directory and can be run with `pytest`:
+Unit tests are located in the `tests` directory. Make sure all dependencies are installed and, for faster runs, you may opt into the lightweight embedding mode.
 
 ```bash
-pytest
+pip install -r requirements.txt
+LIGHTWEIGHT_EMBEDDING=1 pytest
 ```
 
-Some stress tests require significant compute time. Set the environment variable `LIGHTWEIGHT_EMBEDDING=1` to avoid downloading heavy models during testing.
+Setting `LIGHTWEIGHT_EMBEDDING=1` avoids downloading heavy models during testing.
 


### PR DESCRIPTION
## Summary
- update testing instructions to mention installing dependencies
- show `LIGHTWEIGHT_EMBEDDING` env var usage with example commands

## Testing
- `LIGHTWEIGHT_EMBEDDING=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68460083d63c832786461046e3be2f7f