### PR TITLE
Clarify httpx pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository contains a minimal implementation of the KIMERA Semantic Working
 
 - Python 3.12+
 - See `requirements.txt` for Python package dependencies.
-- The `httpx` dependency is pinned to `<0.27` due to compatibility with
-  FastAPI's test client.
+- The `httpx` dependency is pinned to `0.24.*` for FastAPI test client
+  compatibility.
 
 Install dependencies with:
 


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Clarified `httpx` version pinning rationale in documentation.

- Updated version specification for `httpx` in `README.md`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Clarify and specify httpx version pinning in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated explanation for <code>httpx</code> dependency pinning.<br> <li> Specified <code>httpx</code> version as <code>0.24.*</code> for FastAPI compatibility.


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/34/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>