### PR TITLE
Add env-controlled job startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ uvicorn backend.api.main:app --reload
 ```
 
 The API exposes endpoints for managing geoids and scars. Static images are served from `static/images`.
+Set the `ENABLE_JOBS` environment variable to `0` if you want to disable the
+recurring background jobs that run on startup (they are enabled by default).
 
 ## Testing
 
@@ -36,4 +38,5 @@ LIGHTWEIGHT_EMBEDDING=1 pytest
 ```
 
 Setting `LIGHTWEIGHT_EMBEDDING=1` avoids downloading heavy models during testing.
+Set `ENABLE_JOBS=0` during testing to skip the background scheduler.
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ uvicorn backend.api.main:app --reload
 ```
 
 The API exposes endpoints for managing geoids and scars. Static images are served from `static/images`.
-Set the `ENABLE_JOBS` environment variable to `0` if you want to disable the
-recurring background jobs that run on startup (they are enabled by default).
+
+### Environment variables
+
+- `ENABLE_JOBS` controls whether periodic background jobs start on startup. Set this variable to `0` to disable them (default `1`).
 
 ## Testing
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -61,7 +61,8 @@ kimera_system = {
 
 @app.on_event("startup")
 def _startup_background_jobs() -> None:
-    start_background_jobs(embedding_model.encode)
+    if os.getenv("ENABLE_JOBS", "1") == "1":
+        start_background_jobs(embedding_model.encode)
 
 
 @app.on_event("shutdown")

--- a/tests/stress/test_system_stress.py
+++ b/tests/stress/test_system_stress.py
@@ -8,6 +8,7 @@ import random
 import string
 
 sys.path.insert(0, os.path.abspath("."))
+os.environ["ENABLE_JOBS"] = "0"
 
 from apscheduler.schedulers.background import BackgroundScheduler
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import sys
 
 # Use fresh database for tests
 os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+os.environ["ENABLE_JOBS"] = "0"
 if os.path.exists("./test.db"):
     os.remove("./test.db")
 


### PR DESCRIPTION
### **User description**
## Summary
- gate background jobs behind `ENABLE_JOBS` env variable
- update README with instructions about `ENABLE_JOBS`
- disable background jobs in tests

## Testing
- `pip install -q -r requirements.txt` *(fails: command interrupted)*
- `pytest -q` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68462619720883279cfc28cd558d5320


___

### **PR Type**
enhancement, documentation, tests


___

### **Description**
- Add `ENABLE_JOBS` environment variable to control background job startup
  - Only start background jobs if `ENABLE_JOBS` is set to "1" (default)

- Update test files to disable background jobs during test runs

- Document `ENABLE_JOBS` usage in the README for both normal use and testing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add env check for background job startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/api/main.py

<li>Wrap background job startup in <code>ENABLE_JOBS</code> env check<br> <li> Only start jobs if <code>ENABLE_JOBS</code> is "1"


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/36/files#diff-7edeb9df8aa8ec3c8e87e46c4f9bb574f848c16cb5a061fcc640ce4cadfefca3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_system_stress.py</strong><dd><code>Disable background jobs in stress tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/stress/test_system_stress.py

- Set `ENABLE_JOBS` to "0" to disable jobs during stress tests


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/36/files#diff-9032d44c74f6ab1a46c4cf6290e22bf1b98c3f64ff5bb63578e47f9affc7b22a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Disable background jobs in API tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_api.py

- Set `ENABLE_JOBS` to "0" to disable jobs during API tests


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/36/files#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document `ENABLE_JOBS` usage and testing advice</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Add instructions for using <code>ENABLE_JOBS</code> to control background jobs<br> <li> Recommend setting <code>ENABLE_JOBS=0</code> during testing


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/36/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>