### PR TITLE
Add SPDE and KCCL engine stubs

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -16,6 +16,8 @@ from ..core.embedding_utils import encode_text
 from ..engines.contradiction_engine import ContradictionEngine, TensionGradient
 from ..engines.thermodynamics import SemanticThermodynamicsEngine
 from ..engines.asm import AxisStabilityMonitor
+from ..engines.spde import SPDE
+from ..engines.kccl import KimeraCognitiveCycle
 from ..vault.vault_manager import VaultManager
 from ..vault.database import SessionLocal, GeoidDB, ScarDB
 from ..engines.background_jobs import start_background_jobs, stop_background_jobs
@@ -32,6 +34,8 @@ kimera_system = {
     'contradiction_engine': ContradictionEngine(),
     'thermodynamics_engine': SemanticThermodynamicsEngine(),
     'vault_manager': VaultManager(),
+    'spde_engine': SPDE(),
+    'cognitive_cycle': KimeraCognitiveCycle(),
     'active_geoids': {},
     'system_state': {'cycle_count': 0}
 }

--- a/backend/engines/asm.py
+++ b/backend/engines/asm.py
@@ -33,10 +33,15 @@ class AxisStabilityMonitor:
         if len(recent_geoids) > 1:
             vectors = [g.semantic_vector for g in recent_geoids if g.semantic_vector is not None]
             if len(vectors) > 1:
+                min_len = min(len(v) for v in vectors)
+                norm_vectors = [np.array(v[:min_len]) for v in vectors]
                 # Compute pairwise cosine distances without heavy dependencies
-                distances = pdist(np.array(vectors), metric="cosine")
+                distances = pdist(np.vstack(norm_vectors), metric="cosine")
                 avg_distance = float(np.mean(distances))
-                semantic_cohesion = 1.0 - avg_distance
+                if np.isnan(avg_distance):
+                    semantic_cohesion = 0.0
+                else:
+                    semantic_cohesion = 1.0 - avg_distance
 
         # Metric 3: Entropic Stability - trend of entropy change
         recent_scars = (

--- a/backend/engines/kccl.py
+++ b/backend/engines/kccl.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+class KimeraCognitiveCycle:
+    """Simplified core cognitive loop placeholder."""
+
+    def run_cycle(self) -> str:
+        """Execute one cognitive cycle."""
+        return "cycle complete"

--- a/backend/engines/spde.py
+++ b/backend/engines/spde.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+class SPDE:
+    """Semantic Pressure Diffusion Engine placeholder."""
+
+    def diffuse(self, state: dict[str, float]) -> dict[str, float]:
+        """Return a lightly diffused copy of the state."""
+        if not state:
+            return {}
+        avg = sum(state.values()) / len(state)
+        return {k: (v + avg) / 2 for k, v in state.items()}

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from backend.engines.spde import SPDE
+from backend.engines.kccl import KimeraCognitiveCycle
+
+
+def test_spde_basic():
+    eng = SPDE()
+    out = eng.diffuse({'a': 1.0, 'b': 0.0})
+    assert isinstance(out, dict)
+    assert set(out) == {'a', 'b'}
+
+
+def test_kccl_basic():
+    cycle = KimeraCognitiveCycle()
+    assert cycle.run_cycle() == 'cycle complete'


### PR DESCRIPTION
## Summary
- implement minimal `SPDE` and `KimeraCognitiveCycle` classes
- expose new engines through `kimera_system`
- stabilize `AxisStabilityMonitor` handling of vectors of different lengths
- test that the new engines can be instantiated

## Testing
- `pytest -q tests/test_api.py tests/test_engines.py`

------
https://chatgpt.com/codex/tasks/task_e_68462f8fe83c8327ae931beb1dd4bd91