### PR TITLE
Implement EchoForm parser

### DIFF
--- a/backend/linguistic/echoform.py
+++ b/backend/linguistic/echoform.py
@@ -1,0 +1,51 @@
+"""Minimal EchoForm parser.
+
+This module provides :func:`parse_echoform` to transform a text string written
+in a very small subset of EchoForm into a nested list representation. The
+supported syntax resembles s-expressions where parentheses denote nested
+structures. Tokens are separated by whitespace. No quoting or escaping is
+implemented -- this is intentionally lightweight for the unit tests.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+_TOKEN_RE = re.compile(r"\(|\)|[^\s()]+")
+
+
+def _parse_tokens(tokens: List[str], pos: int = 0) -> Tuple[List, int]:
+    """Recursive descent parser returning a nested list and next position."""
+    result: List = []
+    while pos < len(tokens):
+        tok = tokens[pos]
+        if tok == "(":
+            sub, pos = _parse_tokens(tokens, pos + 1)
+            result.append(sub)
+        elif tok == ")":
+            return result, pos + 1
+        else:
+            result.append(tok)
+            pos += 1
+    return result, pos
+
+
+def parse_echoform(text: str) -> List:
+    """Parse a string of EchoForm into a nested list structure.
+
+    Parameters
+    ----------
+    text: str
+        Raw EchoForm text. Parentheses must be balanced.
+
+    Returns
+    -------
+    list
+        Nested list representation of the form.
+    """
+    tokens = _TOKEN_RE.findall(text)
+    ast, pos = _parse_tokens(tokens)
+    if pos != len(tokens):
+        raise ValueError("Unbalanced parentheses in EchoForm")
+    return ast

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -149,3 +149,17 @@ def test_speak_geoid_endpoint():
     gid = create.json()['geoid_id']
     res = client.get(f'/geoids/{gid}/speak')
     assert res.status_code in (200, 409)
+
+
+def test_echoform_parsing_and_storage():
+    res = client.post(
+        '/geoids',
+        json={
+            'semantic_features': {'e': 1.0},
+            'echoform_text': '(hello world (nested))'
+        },
+    )
+    assert res.status_code == 200
+    gid = res.json()['geoid_id']
+    geoid = kimera_system['active_geoids'][gid]
+    assert geoid.symbolic_state['echoform'] == [['hello', 'world', ['nested']]]


### PR DESCRIPTION
### **User description**
## Summary
- implement simple EchoForm parser returning nested lists
- allow `/geoids` to accept EchoForm text
- store parsed EchoForm structure inside geoid symbolic_state
- test EchoForm parsing via API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68463a96527c83278337a3c7fd89ddfd


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add EchoForm parser for nested list parsing.

- Integrate EchoForm parsing into geoid creation API.

- Store parsed EchoForm in geoid symbolic state.

- Add test for EchoForm parsing and storage via API.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>echoform.py</strong><dd><code>Add minimal EchoForm parser for nested list conversion</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/linguistic/echoform.py

<li>Introduce minimal EchoForm parser module.<br> <li> Provide <code>parse_echoform</code> to convert EchoForm text to nested lists.<br> <li> Implement recursive descent parsing for s-expression-like syntax.<br> <li> Raise error on unbalanced parentheses.


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/41/files#diff-39befaac6a711c2c79cc4346af38c6ea8a2b0728c8ae78f644962e762d1d055b">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Integrate EchoForm parsing into geoid creation endpoint</code>&nbsp; &nbsp; </dd></summary>
<hr>

backend/api/main.py

<li>Import and use EchoForm parser in geoid creation endpoint.<br> <li> Extend geoid creation request model with <code>echoform_text</code> field.<br> <li> Parse and store EchoForm structure in geoid's symbolic state.<br> <li> Add error handling for invalid EchoForm input.


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/41/files#diff-7edeb9df8aa8ec3c8e87e46c4f9bb574f848c16cb5a061fcc640ce4cadfefca3">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Add API test for EchoForm parsing and storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_api.py

<li>Add test for EchoForm parsing and storage via API.<br> <li> Verify parsed EchoForm is stored in geoid symbolic state.


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/41/files#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Additional files</strong></td><td><table>
<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/41/files#diff-55da3c8a545fdfae91c8fc21bb7a943ce7ab5984eb8bd4d3ed3e86578df3a9d8">[link]</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>