### PR TITLE
Improve EchoForm parser with quote operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ The endpoint `/geoids` accepts an optional `echoform_text` field that is parsed
 using the lightweight EchoForm parser implemented in
 `backend/linguistic/echoform.py`.
 The parser supports a small s-expression style syntax where parentheses denote
-nested lists and tokens are separated by whitespace. Submitting EchoForm text
-stores the parsed structure in the Geoid's symbolic state.
+nested lists and tokens are separated by whitespace.  Double quoted strings are
+treated as string atoms and the single quote character functions as the Lisp
+style `quote` operator.  Submitting EchoForm text stores the parsed structure in
+the Geoid's symbolic state.
 
 Example request:
 

--- a/backend/linguistic/echoform.py
+++ b/backend/linguistic/echoform.py
@@ -1,33 +1,103 @@
-"""Minimal EchoForm parser.
+"""Minimal EchoForm parser with quoting and basic atom types.
 
 This module provides :func:`parse_echoform` to transform a text string written
-in a very small subset of EchoForm into a nested list representation. The
-supported syntax resembles s-expressions where parentheses denote nested
-structures. Tokens are separated by whitespace. No quoting or escaping is
-implemented -- this is intentionally lightweight for the unit tests.
+in a small subset of EchoForm into a nested list representation.  The syntax
+resembles s-expressions where parentheses denote nested structures.  In
+addition to plain tokens separated by whitespace, the parser understands
+quoted tokens using single or double quotes and will convert numeric atoms to
+``int`` or ``float`` values.  No advanced escaping is implemented; the goal is
+to keep this lightweight for unit testing.
 """
 
 from __future__ import annotations
 
 import re
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
+# Tokenizer supporting quoted strings and the quote operator. Quotes themselves
+# are preserved so the parser can strip them after tokenisation. The single
+# quote character is treated as a separate token so `'expr` can be expanded to
+# ``['quote', expr]`` during parsing.
 _TOKEN_RE = re.compile(r"\(|\)|[^\s()]+")
 
 
-def _parse_tokens(tokens: List[str], pos: int = 0) -> Tuple[List, int]:
+def _tokenize(text: str) -> List[str]:
+    """Tokenize the input EchoForm text."""
+    tokens: List[str] = []
+    i = 0
+    while i < len(text):
+        c = text[i]
+        if c.isspace():
+            i += 1
+            continue
+        if c in "()":
+            tokens.append(c)
+            i += 1
+            continue
+        if c == "'":
+            tokens.append("'")
+            i += 1
+            continue
+        if c == '"':
+            j = i + 1
+            buf = []
+            while j < len(text):
+                if text[j] == '"' and text[j - 1] != "\\":
+                    break
+                buf.append(text[j])
+                j += 1
+            else:
+                raise ValueError("Unterminated string literal")
+            tokens.append('"' + ''.join(buf) + '"')
+            i = j + 1
+            continue
+
+        j = i
+        while j < len(text) and not text[j].isspace() and text[j] not in "()'":
+            j += 1
+        tokens.append(text[i:j])
+        i = j
+    return tokens
+
+
+def _atom(tok: str) -> Any:
+    """Convert a token to an atomic Python value."""
+    if (tok.startswith('"') and tok.endswith('"')) or (
+        tok.startswith("'") and tok.endswith("'")
+    ):
+        return tok[1:-1]
+    if re.fullmatch(r"-?\d+", tok):
+        return int(tok)
+    if re.fullmatch(r"-?\d*\.\d+", tok):
+        return float(tok)
+    return tok
+
+
+def _parse_item(tokens: List[str], pos: int) -> Tuple[Any, int]:
+    """Parse a single item starting at ``pos`` and return it with next index."""
+    if pos >= len(tokens):
+        raise ValueError("Unexpected end of input")
+
+    tok = tokens[pos]
+    if tok == "(":
+        lst, pos = _parse_tokens(tokens, pos + 1)
+        return lst, pos
+    if tok == "'":
+        item, pos = _parse_item(tokens, pos + 1)
+        return ["quote", item], pos
+    if tok == ")":
+        raise ValueError("Unexpected ')' in EchoForm")
+    return _atom(tok), pos + 1
+
+
+def _parse_tokens(tokens: List[str], pos: int = 0) -> Tuple[List[Any], int]:
     """Recursive descent parser returning a nested list and next position."""
-    result: List = []
+    result: List[Any] = []
     while pos < len(tokens):
-        tok = tokens[pos]
-        if tok == "(":
-            sub, pos = _parse_tokens(tokens, pos + 1)
-            result.append(sub)
-        elif tok == ")":
+        if tokens[pos] == ")":
             return result, pos + 1
-        else:
-            result.append(tok)
-            pos += 1
+        item, pos = _parse_item(tokens, pos)
+        result.append(item)
     return result, pos
 
 
@@ -44,7 +114,7 @@ def parse_echoform(text: str) -> List:
     list
         Nested list representation of the form.
     """
-    tokens = _TOKEN_RE.findall(text)
+    tokens = _tokenize(text)
     ast, pos = _parse_tokens(tokens)
     if pos != len(tokens):
         raise ValueError("Unbalanced parentheses in EchoForm")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -164,6 +164,23 @@ def test_echoform_parsing_and_storage(api_env):
     assert geoid.symbolic_state['echoform'] == [['hello', 'world', ['nested']]]
 
 
+def test_complex_echoform_parsing(api_env):
+    client, kimera_system, *_ = api_env
+    text = "(greet 'world (+ 1 2) '(nested a))"
+    res = client.post(
+        '/geoids',
+        json={
+            'semantic_features': {'c': 1.0},
+            'echoform_text': text
+        },
+    )
+    assert res.status_code == 200
+    gid = res.json()['geoid_id']
+    geoid = kimera_system['active_geoids'][gid]
+    expected = [['greet', ['quote', 'world'], ['+', 1, 2], ['quote', ['nested', 'a']]]]
+    assert geoid.symbolic_state['echoform'] == expected
+
+
 def test_system_cycle_endpoint(api_env):
     client, kimera_system, *_ = api_env
     g1 = client.post('/geoids', json={'semantic_features': {'c1': 1.0}})


### PR DESCRIPTION
### **User description**
## Summary
- extend EchoForm tokenizer to treat `'` as the quote operator
- implement recursive parsing of `'expr` into `["quote", expr]`
- document quoting semantics in README
- update complex EchoForm test for new behavior

## Testing
- `pip install -r requirements.txt` *(fails: network unreachable)*
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6846e09701a08327845a28f3659ca371


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Enhanced EchoForm parser to support quoting and atom types
  - Added support for single quote as quote operator
  - Added parsing for quoted strings and numeric atoms

- Updated and expanded EchoForm parsing tests for new quoting behavior

- Improved documentation to describe new quoting and atom features


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>echoform.py</strong><dd><code>Enhanced EchoForm parser with quoting and atom support</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/linguistic/echoform.py

<li>Rewrote tokenizer to handle quoted strings and quote operator<br> <li> Added parsing logic for quote operator and atom conversion (int, <br>float, string)<br> <li> Refactored recursive parsing to support new token types<br> <li> Improved error handling for unterminated strings and unexpected tokens


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/49/files#diff-39befaac6a711c2c79cc4346af38c6ea8a2b0728c8ae78f644962e762d1d055b">+87/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Added tests for quoted and numeric EchoForm parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_api.py

<li>Added test for complex EchoForm parsing with quotes and numbers<br> <li> Verified correct parsing and storage of quoted and numeric forms


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/49/files#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Documented quoting and atom features in EchoForm parser</code>&nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated EchoForm parser documentation to describe quoting and atom <br>support<br> <li> Clarified handling of quoted strings and quote operator


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/49/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>