### PR TITLE
Add test runner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,16 @@ weights.
 
 ## Testing
 
-Unit tests are located in the `tests` directory. Make sure all dependencies are installed and, for faster runs, you may opt into the lightweight embedding mode.
+Unit tests are located in the `tests` directory. After installing the
+dependencies, run the helper script to execute all tests in lightweight mode.
 
 ```bash
 pip install -r requirements.txt
-LIGHTWEIGHT_EMBEDDING=1 pytest
+./scripts/run_tests.sh
 ```
 
-Setting `LIGHTWEIGHT_EMBEDDING=1` avoids downloading heavy models during testing.
-Set `ENABLE_JOBS=0` during testing to skip the background scheduler.
+The script enables the lightweight embedding mode and disables background jobs
+so that heavy models are not downloaded during testing.
 
 ## EchoForm parser
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Run pytest with lightweight embedding and jobs disabled
+export LIGHTWEIGHT_EMBEDDING=1
+export ENABLE_JOBS=0
+pytest "$@"


### PR DESCRIPTION
## Summary
- add `scripts/run_tests.sh` to run pytest with the proper environment
- document the helper script in the testing section of the README

## Testing
- `./scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684705cfa7308327966aefd083412d85