### PR TITLE
Add vault rebalance tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -229,4 +229,8 @@ def test_vault_rebalance_endpoint(api_env):
     assert res.status_code == 200
     data = res.json()
     assert 'moved_scars' in data
+    with SessionLocal() as db:
+        count_a = db.query(ScarDB).filter(ScarDB.vault_id == 'vault_a').count()
+        count_b = db.query(ScarDB).filter(ScarDB.vault_id == 'vault_b').count()
+    assert count_a == 2 and count_b == 2
 

--- a/tests/test_vault_manager.py
+++ b/tests/test_vault_manager.py
@@ -55,9 +55,11 @@ def test_detect_and_rebalance_counts(vault_env):
     assert imbal and over == "vault_a"
 
     moved = vm.rebalance_vaults()
-    assert moved > 0
-    balanced, *_ = vm.detect_vault_imbalance()
-    assert not balanced
+    assert moved == 3
+    with SessionLocal() as db:
+        count_a = db.query(ScarDB).filter(ScarDB.vault_id == "vault_a").count()
+        count_b = db.query(ScarDB).filter(ScarDB.vault_id == "vault_b").count()
+    assert count_a == 3 and count_b == 3
 
 
 def test_detect_imbalance_by_weight(vault_env):
@@ -80,4 +82,24 @@ def test_detect_imbalance_by_weight(vault_env):
 
     imbal, over, _ = vm.detect_vault_imbalance(by_weight=True)
     assert imbal and over in {"vault_a", "vault_b"}
+
+
+def test_rebalance_by_weight_moves_correct_scars(vault_env):
+    vm, SessionLocal, ScarDB = vault_env
+    with SessionLocal() as db:
+        db.query(ScarDB).delete()
+        db.commit()
+    weights = [1.0, 2.0, 2.0, 5.0]
+    for i, w in enumerate(weights):
+        vm.insert_scar(_make_scar(20 + i, weight=w), [0.0])
+    with SessionLocal() as db:
+        db.query(ScarDB).update({ScarDB.vault_id: "vault_a"})
+        db.commit()
+
+    moved = vm.rebalance_vaults(by_weight=True)
+    assert moved == 3
+    weight_a = vm.get_total_scar_weight("vault_a")
+    weight_b = vm.get_total_scar_weight("vault_b")
+    assert weight_a == pytest.approx(5.0)
+    assert weight_b == pytest.approx(5.0)
 


### PR DESCRIPTION
### **User description**
## Summary
- ensure vault rebalancing by count moves exactly half the difference
- verify weight-based rebalancing balances vault weights
- check vault rebalance endpoint returns balanced counts

## Testing
- `pytest tests/test_vault_manager.py::test_detect_and_rebalance_counts tests/test_vault_manager.py::test_rebalance_by_weight_moves_correct_scars tests/test_api.py::test_vault_rebalance_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_68473242e2708327860f18ff97c8baa4


___

### **PR Type**
Tests


___

### **Description**
- Add comprehensive tests for vault rebalancing logic
  - Verify count-based rebalancing splits items evenly
  - Ensure weight-based rebalancing balances vault weights
  - Confirm API endpoint returns balanced vaults

- Enhance test assertions for precise balance checks


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_api.py</strong><dd><code>Add post-rebalance balance assertions to API test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_api.py

<li>Add assertions to verify vaults are balanced after API rebalance<br> <li> Check both vaults have equal item counts post-rebalance


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/58/files#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_vault_manager.py</strong><dd><code>Add and enhance vault manager rebalance tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_vault_manager.py

<li>Strengthen count-based rebalance test with exact count checks<br> <li> Add new test for weight-based rebalance correctness<br> <li> Assert precise distribution of weights after rebalancing


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/MVP_KIMERA/pull/58/files#diff-19d648cca20ed00fe7fa853fe12db87ff3413c78660d1d35244b177208475bc4">+25/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>