### PR TITLE
Parse EchoForm on geoid creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,23 @@ curl -X POST http://localhost:8000/geoids \
          "echoform_text": "(hello (world))"}'
 ```
 
-The response returns the new `geoid_id` and the symbolic state will contain the
-parsed EchoForm list `[["hello", ["world"]]]`.
+Example response (truncated for brevity):
+
+```json
+{
+  "geoid_id": "GEOID_1234ABCD",
+  "geoid": {
+    "geoid_id": "GEOID_1234ABCD",
+    "semantic_state": {"greet": 1.0},
+    "symbolic_state": {"echoform": [["hello", ["world"]]]},
+    "metadata": {}
+  },
+  "entropy": 0.0
+}
+```
+
+The `symbolic_state` now contains the parsed EchoForm list under the
+`"echoform"` key.
 
 ## Cognitive cycle and vaults
 

--- a/tests/test_echoform_parser.py
+++ b/tests/test_echoform_parser.py
@@ -1,0 +1,12 @@
+import pytest
+from backend.linguistic.echoform import parse_echoform
+
+@pytest.mark.parametrize("text,expected", [
+    ("(hello world)", [["hello", "world"]]),
+    ("(greet 'world)", [["greet", ["quote", "world"]]]),
+    ("(add 1 2.5)", [["add", 1, 2.5]]),
+])
+def test_parse_echoform_valid(text, expected):
+    assert parse_echoform(text) == expected
+
+


### PR DESCRIPTION
## Summary
- document EchoForm parsing in README
- remove sys.path modification from EchoForm parser tests
- add EchoForm parser tests

## Testing
- `pytest tests/test_echoform_parser.py tests/test_api.py::test_echoform_parsing_and_storage tests/test_api.py::test_complex_echoform_parsing -q`

------
https://chatgpt.com/codex/tasks/task_e_684736e363408327bc7499e4fe9c3267