### PR TITLE
Control background jobs via env

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -44,7 +44,7 @@ kimera_system = {
 
 @app.on_event("startup")
 def _startup_background_jobs() -> None:
-    if os.getenv("ENABLE_JOBS", "1") == "1":
+    if os.getenv("ENABLE_JOBS", "1") != "0":
         start_background_jobs(encode_text)
 
 

--- a/tests/test_echoform_parser.py
+++ b/tests/test_echoform_parser.py
@@ -1,4 +1,7 @@
+import os
 import pytest
+
+os.environ["ENABLE_JOBS"] = "0"
 from backend.linguistic.echoform import parse_echoform
 
 @pytest.mark.parametrize("text,expected", [

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -2,6 +2,8 @@ import os
 import sys
 import pytest
 
+os.environ["ENABLE_JOBS"] = "0"
+
 sys.path.insert(0, os.path.abspath('.'))
 
 from backend.engines.spde import SPDE

--- a/tests/test_vault_manager.py
+++ b/tests/test_vault_manager.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import importlib
+
+os.environ["ENABLE_JOBS"] = "0"
 from datetime import datetime
 import pytest
 


### PR DESCRIPTION
## Summary
- allow starting background jobs only when `ENABLE_JOBS` is not `0`
- set `ENABLE_JOBS=0` in unit tests so jobs never run

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68473fce086c83279ad921e9b9d73ef7